### PR TITLE
Feat/post eezy

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -43,7 +43,8 @@ INSTALLED_APPS = [
     'squeeze.apps.SqueezeConfig',
     'eezy.apps.EezyConfig',
     'rest_framework',
-    'corsheaders'
+    'corsheaders',
+    'rest_framework.authtoken',  # Add this line
 ]
 
 MIDDLEWARE = [
@@ -62,6 +63,10 @@ CORS_ALLOWED_ORIGINS = [
     "http://127.0.0.1:8000",
     "http://localhost:8000",
     # 필요한 다른 도메인 추가
+]
+
+CSRF_TRUSTED_ORIGINS = [
+    'chrome-extension://oamcggejfblocnjfhjboglmobhejhane'
 ]
 
 ROOT_URLCONF = 'config.urls'
@@ -138,3 +143,9 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 AUTH_USER_MODEL = 'users.User'
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.TokenAuthentication',
+    ],
+}

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,8 +16,10 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from rest_framework.authtoken.views import obtain_auth_token
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/eezy/', include('eezy.urls'))
+    path('api/eezy/', include('eezy.urls')),
+    path('api-token-auth/', obtain_auth_token, name='api_token_auth'),
 ]

--- a/eezy/views.py
+++ b/eezy/views.py
@@ -40,7 +40,7 @@ class EezyView(APIView):
             return Response({"error": f"Input length exceeds {max_input_length} characters"}, status=status.HTTP_400_BAD_REQUEST)   
 
         try:
-            '''response = client.chat.completions.create(
+            response = client.chat.completions.create(
                 model="gpt-3.5-turbo",
                 messages=[
                     {"role": "system", "content": "You are a helpful assistant."},
@@ -54,8 +54,12 @@ class EezyView(APIView):
                 max_tokens=700
             )
             result = response.choices[0].message.content.strip()
-            result_json = json.loads(result)'''
-            result_json = {"title": "test", "content": html_content, "tab":tab}
+
+            if result.startswith("```json"):
+                result = result[7:-3].strip()
+            print(response.choices[0])
+            result_json = json.loads(result)
+            '''result_json = {"title": "test", "content": html_content, "tab":tab}'''
             eezy = Eezy.objects.create(title=result_json['title'], content=result_json['content'], tab=tab)
             serializer = EezySerializer(eezy)
             return Response(serializer.data, status=status.HTTP_200_OK)

--- a/eezy/views.py
+++ b/eezy/views.py
@@ -47,7 +47,7 @@ class EezyView(APIView):
                     {"role": "user", "content": (
                         "다음 HTML 콘텐츠의 제목을 추출하고 요약해 주세요. "
                         "요약본은 노션에 적합한 마크다운 형식으로 작성해 주세요. "
-                        "결과는 'title'과 'content' 필드를 포함하는 JSON 객체로 반환해 주세요:\n\n"
+                        "결과는 'content' 필드를 포함하는 JSON 객체로 반환해 주세요:\n\n"
                         f"{html_content}\n\n"
                     )}
                 ],
@@ -60,7 +60,7 @@ class EezyView(APIView):
             print(response.choices[0])
             result_json = json.loads(result)
             '''result_json = {"title": "test", "content": html_content, "tab":tab}'''
-            eezy = Eezy.objects.create(title=result_json['title'], content=result_json['content'], tab=tab)
+            eezy = Eezy.objects.create(title=tab.title, content=result_json['content'], tab=tab)
             serializer = EezySerializer(eezy)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Exception as e:

--- a/some_app/views.py
+++ b/some_app/views.py
@@ -1,0 +1,9 @@
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
+class SomeProtectedView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        return Response({"message": "This is a protected view"})


### PR DESCRIPTION
## What
- django의 기본값인 세션 로그인 방식에서 토큰 인증 방식으로 변경
- 관리자 페이지에 토큰 관리 페이지 생성
- 로그인 기능이 완성되기 전까지는 관리자 계정의 토큰을 사용해서 테스트합니다.

## Why
확장 프로그램의 특성 상 세션 로그인이 불가능하기 때문에 토큰 인증 방식으로 변경했습니다.

## How to Test
1. 관리자 페이지로 이동
2. 토큰을 관리하는 페이지가 새로 생긴 것을 확인

## Screenshots
(스크린샷을 첨부할 수 있다면 여기 넣기)
