### PR TITLE
feat: get-eezy 기능 추가

### DIFF
--- a/eezy/admin.py
+++ b/eezy/admin.py
@@ -4,4 +4,4 @@ from .models import Eezy
 # Register your models here.
 @admin.register(Eezy)
 class EezyAdmin(admin.ModelAdmin):
-    list_display = ['title', 'tab', 'tab__user']
+    list_display = ['title', 'tab']

--- a/eezy/serializers.py
+++ b/eezy/serializers.py
@@ -4,8 +4,7 @@ from tabs.models import Tab
 from tabs.serializers import TabSerializer
 
 class EezySerializer(ModelSerializer):
+    tab = TabSerializer(read_only=True)
     class Meta:
         model = Eezy
         fields = ['id', 'title', 'content', 'tab']
-
-        tab = TabSerializer(read_only=True)

--- a/eezy/tests.py
+++ b/eezy/tests.py
@@ -1,3 +1,29 @@
 from django.test import TestCase
 
-# Create your tests here.
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from tabs.models import Tab
+from eezy.models import Eezy
+from users.models import User
+
+class EezyViewTest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create(username="testuser")
+        self.tab = Tab.objects.create(user=self.user, title="UX란?", url="www.com")
+        self.eezy = Eezy.objects.create(title="UX UI 기초", content="대충 페이지 요약한 내용.....", tab=self.tab)
+
+    def test_get_eezy(self):
+        url = reverse('eezy-detail', args=[self.eezy.id])
+        response = self.client.get(url)
+
+        expected_data = {
+            "id": self.eezy.id,
+            "title": self.eezy.title,
+            "content": self.eezy.content,
+            "tab": {
+                "id": self.tab.id,
+                "title": self.tab.title,
+                "url": self.tab.url
+            }
+        }
+        self.assertEqual(response.json(), expected_data)

--- a/eezy/urls.py
+++ b/eezy/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from .views import EezyView
 
 urlpatterns = [
-    path('', EezyView.as_view())
+    path('', EezyView.as_view()),
+    path('<int:eezy_id>/', EezyView.as_view(), name='eezy-detail'),
 ]

--- a/eezy/views.py
+++ b/eezy/views.py
@@ -20,6 +20,14 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 client = openai.OpenAI(api_key=openai.api_key)
 
 class EezyView(APIView):
+    
+    def get(self, request, eezy_id):
+        try:
+            eezy = Eezy.objects.get(id=eezy_id)
+            serializer = EezySerializer(eezy)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except Eezy.DoesNotExist:
+            return Response({"error": "Eezy not found"}, status=status.HTTP_404_NOT_FOUND)
 
     def post(self, request):
         test_user = User.objects.get(username='mongsam2')
@@ -65,3 +73,4 @@ class EezyView(APIView):
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Exception as e:
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    


### PR DESCRIPTION
## What
해당 pr에선 eezy(특정 탭의 요약본)를 조회하는 기능을 제공합니다. 또한 migrate 시 난 몇 오류들을 해결합니다.
- eezy app 에서만 수정
- admin.py -> list_display에서 tab__user 삭제
    - migrate 시 tab__user 를 불러오는 과정에서 계속해서 오류가 발생하여 삭제
    - 어차피 tab을 불러오면 그 안에서 수정하므로 문제없는 것 같습니다
- serializers.py -> tab = TabSerializer(read_only=True) 의 위치 수정
    - 이전엔 Meta 클래스 안의 맨 아래 있었으나, Meta 클래스 외부 맨 위로 위치 수정
    - migrate 시에 tab을 불러올 때 계속해서 오류가 나, 이의 해결을 위해 수정
- tests.py -> get-eezy 기능 테스트를 위한 메소드 2개 추가
- urls.py -> eezy_id로 get 해오기 위한 url 패턴 추가
- views.py -> get method 추가

## Why

## How to Test
현재는 로컬 서버에서 테스트하여, 배포 서버에 대한 테스트는 존재하지 않습니다.

## Screenshots
<img width="1008" alt="ScreenShot 2024-11-07 오후 9 21 41" src="https://github.com/user-attachments/assets/f424caff-3406-4b13-bba7-b25989b31471">

## Additional Information
...