### PR TITLE
feat: 로컬 테스트 환경과 배포 환경 분리

### DIFF
--- a/config/local.py
+++ b/config/local.py
@@ -1,0 +1,3 @@
+from .settings import *
+
+DEBUG = True

--- a/config/settings.py
+++ b/config/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'django-insecure-t_dv&(qls7_fl@=)#(%qcv34y7y1=l-^ipelf*$^+9183=s5x&'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = ['13.124.143.64', '127.0.0.1']
 


### PR DESCRIPTION
## What
config settings.py 로컬 버전과 배포 버전을 분리해서 사용

## Why
배포환경에서 pull 할 때마다 settings.py를 바꿔줘야하는 불편함을 개선

## How to Test
로컬환경에서 실행할 때는 
<code>python manage.py runserver --settings=config.local<!code>
명령어로 입력

## Screenshots
(스크린샷을 첨부할 수 있다면 여기 넣기)

## Additional Information
...
