### PR TITLE
fix: user 프로필 조회 수정

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -19,6 +19,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
                 "type": "squeezy",
                 "id": squeeze.id,
                 "title": squeeze.title,
+                "count": squeeze.tabs.count(),
                 "created_at": squeeze.created_at,
             }
             for squeeze in squeeze_qs
@@ -27,6 +28,7 @@ class UserProfileSerializer(serializers.ModelSerializer):
                 "type": "eezy",
                 "id": eezy.id,
                 "title": eezy.title,
+                "content": eezy.content,
                 "created_at": eezy.created_at,
             }
             for eezy in eezy_qs


### PR DESCRIPTION
## What
이 PR은 유저 프로필 조회 기능 수정에 관련합니다.

## Why
response body 수정

eezy의 content는 미리보기에 필요
squeeze의 count: 포함된 탭 개수

## How to Test
로컬 서버에서 테스트 가능합니다.

## Screenshots
<img width="1061" alt="ScreenShot 2024-11-19 오후 5 20 20" src="https://github.com/user-attachments/assets/20012019-984b-4a6c-9c38-ef7d9560544e">


## Additional Information
...
